### PR TITLE
Bump recurly API version to 2.22

### DIFF
--- a/lib/recurly-data.js
+++ b/lib/recurly-data.js
@@ -65,7 +65,7 @@ class RecurlyData {
         'Accept': 'application/xml',
         'Authorization': this._recurring.AUTH_BASIC,
         'User-Agent': `${pkg.name}/${pkg.version}`,
-        'X-Api-Version': '2.7'
+        'X-Api-Version': '2.22'
       }
     }
   }
@@ -87,10 +87,6 @@ class RecurlyData {
     }
 
     options.method = method
-
-    if (uri.startsWith('https://api.recurly.com/v2/invoices')) {
-      options.headers['X-Api-Version'] = '2.10'
-    }
 
     this.execute(options, callback)
   }


### PR DESCRIPTION
Addresses: https://github.com/kontist/figure-app/issues/3568

I have read through all of the changes since the 2.7 API version: https://dev.recurly.com/page/api-release-notes

The only breaking change related to functionality we use seems to be a field name being changed starting in 2.14: https://dev.recurly.com/page/api-release-notes#v214-release-notes
`first_renewal_date` -> `next_bill_date`

The change is documented in their API docs starting from 2.19.

In practice, I have tested with API 2.22 and both fields still achieve the same thing, but I think it's best to update the field name in our code (in case the old one actually gets removed at some point), so I'll do it in the corresponding backend PR.

I have also tested all recurly functionality locally using this new API version, and everything seems to work as before.

If you want to perform such tests to double check:
1.  change recurring field in backendService package.json to `"recurring": "github:kontist/recurring#07520acdcf725cc226b698baed5732e1872dd18daz",`
2. `yarn` to install updated module
3. `yarn up --build` to update module in docker
(you can double check that your Recurly requests use the correct API version in : https://kontist-test.recurly.com/ > Admin > Users > Configure API Access.
There you can see "Last Request" and "API Version" which should be 2.22


Corresponding backend PR: https://github.com/kontist/figure-backend/pull/6213