### PR TITLE
Add subscription update log

### DIFF
--- a/lib/models/subscription.js
+++ b/lib/models/subscription.js
@@ -137,6 +137,12 @@ class Subscription extends RecurlyData {
     this.put(this.href, body, (err, response, payload) => {
       const error = handleRecurlyError(err, response, payload, [ 200, 201 ])
       if (error) {
+        log.error(`[Subscription/update] Error`, {
+          err,
+          error,
+          debugData: options,
+          payload
+        })
         return callback(error)
       }
 


### PR DESCRIPTION
Recurly is throwing weird errors at us in some cases of subscription updates, and I can't reproduce them locally even when I'm in the same state as the user, would like to add some logs here, because currently we only get the http status code and nothing else