### PR TITLE
Fix error handling for update of closed account subscription

### DIFF
--- a/lib/recurly-error.js
+++ b/lib/recurly-error.js
@@ -30,7 +30,7 @@ const RecurlyError = function RecurlyError(struct) {
     this.gateway_error_code = struct.transaction_error.gateway_error_code
   }
   // Handle the case where there is a single validation error.
-  else if (struct.symbol) {
+  else if (struct.symbol != null) {
     // massage the output a little bit...
 
     // {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "recurring",
   "description": "a recurly v2 api client for node.js",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "bugs": "http://github.com/ceejbot/recurring/issues",
   "contributors": [
     "C J Silverio <ceejceej@gmail.com> (http://ceejbot.github.io/)",

--- a/test/test-08-custom-logger.js
+++ b/test/test-08-custom-logger.js
@@ -3,19 +3,28 @@
 const demand = require('must')
 const sinon = require('sinon')
 const Recurring = require('../lib/recurly')
+const logger = require('../lib/logger')
 const recurly = new Recurring()
 
 const nock = require('nock')
 
 describe('Custom logger', function() {
   let customLogger
+  let originalLogger
 
-  it('should call custom logger', function(done) {
+  before(function() {
     customLogger = {
       info: sinon.spy()
     }
+    originalLogger = logger.logger
     recurly.setCustomLogger(customLogger)
+  })
 
+  after(function() {
+    recurly.setCustomLogger(originalLogger)
+  })
+
+  it('should call custom logger', function(done) {
     const amount = 1234
     const usageTimestamp = '1970-01-01T12:00:00Z'
     const addonUsage = recurly.AddonUsage()

--- a/test/test-10-update-closed-account-subscription.js
+++ b/test/test-10-update-closed-account-subscription.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const demand = require('must')
+const Recurring = require('../lib/recurly')
+const recurly = new Recurring()
+
+const nock = require('nock')
+
+describe('Subscription update in case of closed account', function() {
+  it('should call callback with an error', function(done) {
+    const subscription = recurly.Subscription()
+    subscription.id = 'test'
+    const subscriptionData = {
+      timeframe: 'now',
+      unit_amount_in_cents: 900,
+      coupon_code: 'lexoffice100'
+    }
+
+    const xmlResponse = `
+<?xml version="1.0" encoding="UTF-8"?>
+<errors>
+  <error field="subscription.base" symbol="">Subscription cannot be edited. Associated account is closed</error>
+</errors>`.trim()
+
+    nock('https://api.recurly.com/v2')
+      .put(`/subscriptions/${subscription.id}`)
+      .reply(422, xmlResponse)
+
+    subscription.update(subscriptionData, err => {
+      demand(err).to.exist()
+      err.message.must.eql('subscription.base Subscription cannot be edited. Associated account is closed')
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Error handling in `Recurrring` has bug when it fails to parse errors of specific format. As result of it our promisified methods doesn't reject promise correctly and throws errors directly to global error handler. So, it's impossible to catch these errors properly.

This PR adapt error handling to parse such errors.